### PR TITLE
use react-router-route-props-context package for middleware

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,4 @@
+## [v1.0.0]
+> May 16, 2016
+
+- **Major:** get rid of `useRelativeLinks` middleware and use middleware from separate `react-router-route-props-context` package

--- a/README.md
+++ b/README.md
@@ -6,17 +6,18 @@ works, give it a shot, send some pull requests if you run into issues.
 ## Installation
 
 ```
-npm install react-router-relative-links react-router-apply-middleware
+npm install react-router-relative-links react-router-apply-middleware react-router-route-props-context
 ```
 
 ## Usage
 
 ```js
 import applyMiddleware from 'react-router-apply-middleware'
-import { useRelativeLinks, RelativeLink } from 'react-router-relative-links'
+import routePropsContext from 'react-router-route-props-context'
+import { RelativeLink } from 'react-router-relative-links'
 
 // use it like other router middleware
-<Router render={applyMiddleware(useRelativeLinks())}/>
+<Router render={applyMiddleware(routePropsContext())}/>
 
 // now you can use `RelativeLink` anywhere \o/
 <RelativeLink to="../">Up</RelativeLink>

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "examples",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -17,6 +17,7 @@
     "react": "^0.14.7",
     "react-dom": "^0.14.7",
     "react-router-apply-middleware": "0.0.2",
+    "react-router-route-props-context": "^1.0.0",
     "webpack": "^1.12.14",
     "webpack-dev-server": "^1.14.1"
   }

--- a/modules/RelativeLinks.js
+++ b/modules/RelativeLinks.js
@@ -3,45 +3,7 @@ import Link from 'react-router/lib/Link'
 import { formatPattern } from 'react-router/lib/PatternUtils'
 import resolve from 'resolve-pathname'
 
-export const useRelativeLinks = () => ({
-  renderContainer: (Component, props) => (
-    <RelativeLinksContainer Component={Component} routerProps={props}/>
-  )
-})
-
-const { oneOfType, shape, object, string, func, array } = React.PropTypes
-
-const relativeLinksContextType = {
-  relativeLinks: shape({
-    params: object.isRequired,
-    route: object.isRequired,
-    routes: array.isRequired
-  }).isRequired
-}
-
-const RelativeLinksContainer = React.createClass({
-
-  propTypes: {
-    Component: func.isRequired,
-    routerProps: shape({
-      route: object.isRequired,
-      params: object.isRequired
-    }).isRequired
-  },
-
-  childContextTypes: relativeLinksContextType,
-
-  getChildContext() {
-    const { params, routes, route } = this.props.routerProps
-    return { relativeLinks: { params, route, routes } }
-  },
-
-  render() {
-    const { createElement, Component, routerProps } = this.props
-    return createElement(Component, routerProps)
-  }
-
-})
+const { oneOfType, object, string } = React.PropTypes
 
 const isAbsolute = to => to.match(/^\//)
 
@@ -91,7 +53,9 @@ export const RelativeLink = React.createClass({
     to: oneOfType([ string, object ]).isRequired
   },
 
-  contextTypes: relativeLinksContextType,
+  contextTypes: {
+    routeProps: object.isRequired
+  },
 
   getInitialState() {
     return { to: this.calculateTo(this.props) }
@@ -105,7 +69,7 @@ export const RelativeLink = React.createClass({
 
   calculateTo(props) {
     const { to } = props
-    const { route, routes, params } = this.context.relativeLinks
+    const { route, routes, params } = this.context.routeProps
     const isLocationDescriptor = typeof to === 'object'
     const relativePath = isLocationDescriptor ? to.pathname || '' : to
     const resolved = isAbsolute(relativePath) ? relativePath :

--- a/modules/RelativeLinks.test.js
+++ b/modules/RelativeLinks.test.js
@@ -2,7 +2,8 @@
 import React from 'react'
 import expect from 'expect'
 import { Router, Route } from 'react-router'
-import { RelativeLink, useRelativeLinks } from './RelativeLinks'
+import routePropsContext from 'react-router-route-props-context'
+import { RelativeLink } from './RelativeLinks'
 import { render } from 'react-dom'
 import createHistory from 'react-router/lib/createMemoryHistory'
 import applyRouterMiddleware from 'react-router-apply-middleware'
@@ -46,7 +47,7 @@ describe('RelativeLink', () => {
 
       render((
         <Router
-          render={applyRouterMiddleware(useRelativeLinks())}
+          render={applyRouterMiddleware(routePropsContext())}
           routes={routes}
           history={createHistory(initialPath)}
         />
@@ -158,7 +159,7 @@ describe('RelativeLink', () => {
 
       render((
         <Router
-          render={applyRouterMiddleware(useRelativeLinks())}
+          render={applyRouterMiddleware(routePropsContext())}
           routes={routes}
           history={createHistory(initialPath)}
         />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-relative-links",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Name says it all",
   "main": "lib/RelativeLinks.js",
   "repository": {
@@ -24,7 +24,8 @@
   "peerDependencies": {
     "react": "*",
     "react-router": "^2.0.1",
-    "react-router-apply-middleware": "^0.0.2"
+    "react-router-apply-middleware": "^0.0.2",
+    "react-router-route-props-context": "^1.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",
@@ -56,6 +57,7 @@
     "react-dom": "^0.14.2",
     "react-router": "^2.0.1",
     "react-router-apply-middleware": "0.0.2",
+    "react-router-route-props-context": "^1.0.0",
     "rimraf": "^2.4.2",
     "webpack": "^1.12.6",
     "webpack-dev-middleware": "^1.2.0"


### PR DESCRIPTION
instead of `useRelativeLinks()`.

It's always seemed to me that there are a million potential use cases that would benefit from having props for the current route on context.  I think it would be much cleaner if they all got them from a standard place provided by a single package than having every package like this use its own middleware to put the same route props in a separate place on the context.

Note I couldn't get ESLint to work on my machine with the versions/config in this package, but I did run the tests without linting and they passed.
