### PR TITLE
pass extra props through to Component

### DIFF
--- a/modules/RelativeLinks.js
+++ b/modules/RelativeLinks.js
@@ -37,8 +37,8 @@ const RelativeLinksContainer = React.createClass({
   },
 
   render() {
-    const { createElement, Component, routerProps } = this.props
-    return createElement(Component, routerProps)
+    const { createElement, Component, routerProps, ...props } = this.props
+    return createElement(Component, { ...routerProps, ...props })
   }
 
 })


### PR DESCRIPTION
Fix https://github.com/ryanflorence/react-router-relative-links/issues/2
Normally there are no extra props.  However, if the parent route component clones its child route component and adds other props, RelativeLinksContainer currently fails to pass those through to the Component.
